### PR TITLE
Use MediaFrameReader instead of MediaCapture.GetPreviewFrameAsync 

### DIFF
--- a/src/OndertitelLezerUwp/OndertitelLezerUwp.csproj
+++ b/src/OndertitelLezerUwp/OndertitelLezerUwp.csproj
@@ -98,26 +98,26 @@
       <Version>3.0.593</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.2</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
-      <Version>2.0.0</Version>
+      <Version>2.0.1</Version>
     </PackageReference>
     <!-- Nuget package references -->
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.7.1</Version>
+      <Version>2.8.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="WriteableBitmapEx">
-      <Version>1.5.1</Version>
+      <Version>1.6.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/OndertitelLezerUwp/OndertitelLezerUwp.csproj
+++ b/src/OndertitelLezerUwp/OndertitelLezerUwp.csproj
@@ -113,6 +113,9 @@
     <PackageReference Include="Serilog">
       <Version>2.8.0</Version>
     </PackageReference>
+    <PackageReference Include="Serilog.Sinks.Debug">
+      <Version>1.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>4.0.0</Version>
     </PackageReference>

--- a/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
+++ b/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
@@ -98,8 +98,8 @@ namespace OndertitelLezerUwp.ViewModels
         public async Task CleanUp()
         {
             await CleanupCameraAsync();
-            _ocrDetectionService.Reset();
-            _ttsSynthesizer.Reset();
+            _ocrDetectionService?.Reset();
+            _ttsSynthesizer?.Reset();
             _trackSpokenSentences = null;
 
             displayInformation.OrientationChanged -= DisplayInformation_OrientationChanged;

--- a/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
+++ b/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
@@ -32,7 +32,6 @@ namespace OndertitelLezerUwp.ViewModels
     {
         private bool _isOcrStarted = false;
         private OcrDectection _ocrDetectionService;
-        private DispatcherTimer _dispatcherTimer = new DispatcherTimer();
         private readonly CoreDispatcher _dispatcher;
 
         // Receive notifications about rotation of the UI and apply any necessary rotation to the preview stream.     
@@ -79,6 +78,11 @@ namespace OndertitelLezerUwp.ViewModels
             {
                 _ocrDetectionService = new OcrDectection();
                 _ttsSynthesizer = new TtsSynthesizer();
+#if DEBUG
+                Log.Logger = new LoggerConfiguration()
+                    .WriteTo.Debug()
+                    .CreateLogger();
+#endif
             }
             catch (System.Exception exc)
             {
@@ -88,7 +92,7 @@ namespace OndertitelLezerUwp.ViewModels
                 Log.Error(exc.InnerException, "Cannot continue, OCR or Synth base service failure");
                 return;
             }
-            
+
             displayInformation.OrientationChanged += DisplayInformation_OrientationChanged;
 
             await StartCameraAsync();
@@ -115,108 +119,7 @@ namespace OndertitelLezerUwp.ViewModels
         {
             await this._dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await action());
         }
-        
-        private async void _dispatcherTimer_Tick(object sender, object e)
-        {
-            try
-            {
-                await ProcessFrameOcr(_threshold);
-            }
-            catch (System.Exception oexc)
-            {
-                Log.Error(oexc, "Error from await _ocrDetectionService.PerformOcr(bitmapToOcr, _dispatcher);");
-            }
 
-        }
-
-        /// <summary>
-        /// Every x milliseconds, capture a frame from the webcam and process for OCR. 
-        /// </summary>
-        /// <param name="threshold"></param>
-        /// <returns></returns>
-        private async Task ProcessFrameOcr(double threshold)
-        {
-            //Get information about the preview.
-            var previewProperties = _mediaCapture.VideoDeviceController.GetMediaStreamProperties(MediaStreamType.VideoPreview) as VideoEncodingProperties;
-            int videoFrameWidth = (int)previewProperties.Width;
-            int videoFrameHeight = (int)previewProperties.Height;
-            
-            if (!externalCamera && (displayInformation.CurrentOrientation == DisplayOrientations.Portrait || displayInformation.CurrentOrientation == DisplayOrientations.PortraitFlipped))
-            {
-                videoFrameWidth = (int)previewProperties.Height;
-                videoFrameHeight = (int)previewProperties.Width;
-            }
-
-            // Create the video frame to request a SoftwareBitmap preview frame.
-            var videoFrame = new VideoFrame(BitmapPixelFormat.Bgra8, videoFrameWidth, videoFrameHeight);
-
-            // Capture the preview frame.
-            //using (var currentFrame = await _mediaCapture.GetPreviewFrameAsync(videoFrame))
-            using (var currentFrameReference = _mediaFrameReader.TryAcquireLatestFrame())
-            {
-                var currentFrame = currentFrameReference.VideoMediaFrame;
-                // Collect the resulting frame.
-                SoftwareBitmap bitmap = currentFrame.SoftwareBitmap;
-                WriteableBitmap processedBitmap;
-                SoftwareBitmap bitmapToOcr;
-                int oneThirdHeight = bitmap.PixelHeight / 3;
-
-                processedBitmap = new WriteableBitmap(bitmap.PixelWidth, bitmap.PixelHeight);
-                bitmap.CopyToBuffer(processedBitmap.PixelBuffer);
-
-                processedBitmap = await Helpers.ImageProcessor.ApplyGaussianBlur(processedBitmap, 4);
-
-                if (IsImageEffectsOn)
-                {
-                    processedBitmap = await Helpers.ImageProcessor.AdjustCurvesEffect(processedBitmap);
-                    processedBitmap = await Helpers.ImageProcessor.ApplyStampThreshold(processedBitmap, threshold);
-
-                    Log.Information($"IMG - threshold @ {threshold}, gaussian at 4 applied before OCR.");
-                }
-
-                //set the preview image source - if doing image preprocessing and effects
-                if (_isOcrStarted)
-                {
-                    PreviewImageSource = processedBitmap;
-                    PreviewImageIsVisible = true;
-                    CaptureElementIsVisible = false;
-                }
-
-                if (IsOneThirdCapture)
-                {
-                    Rect rectOneThird = new Rect(0, 0, bitmap.PixelWidth, bitmap.PixelHeight / 3);
-                    WriteableBitmap cropped = Helpers.ImageProcessor.CropToRectangle(processedBitmap, rectOneThird);
-                    bitmapToOcr = new SoftwareBitmap(BitmapPixelFormat.Bgra8, cropped.PixelWidth, cropped.PixelHeight);
-                    bitmapToOcr.CopyFromBuffer(cropped.PixelBuffer);
-                }
-                else
-                {
-                    bitmapToOcr = new SoftwareBitmap(BitmapPixelFormat.Bgra8, processedBitmap.PixelWidth, processedBitmap.PixelHeight);
-                    bitmapToOcr.CopyFromBuffer(processedBitmap.PixelBuffer);
-                }
-
-                Tuple<string, int> result = null;
-                
-                result = await _ocrDetectionService.PerformOcr(bitmapToOcr, _accuracyThreshold, _isOneThirdCapture, oneThirdHeight);
-                
-                if (result != null && result.Item1 != null && result.Item1 != "")
-                {
-
-                    //add to internal list keep track of spoken sentences - this is useful if an empty result is returned between two similar Ocr results (can happen if contrast is really bad for a few milliseconds)
-                    if (!SentenceHasBeenSpoken(result.Item1))
-                    {
-                        _trackSpokenSentences.Add(result.Item1);
-                        _ttsSynthesizer.AddUtteranceToSynthesize(result.Item1);
-                        await SpeechSynthiserCall();
-                        Log.Debug($"OCR result spoken and assigning to Textblox onscreen (Conf: {result.Item2}) - {result.Item1}");
-                        OcrResultText = result.Item1;
-                    }
-
-                    StatusMessage = "";
-                    StatusBackground = new SolidColorBrush(Windows.UI.Colors.Transparent);
-                }
-            }
-        }
 
         private bool SentenceHasBeenSpoken(string item1)
         {
@@ -372,8 +275,6 @@ namespace OndertitelLezerUwp.ViewModels
                 CaptureElementIsVisible = true;
 
                 _mediaFrameReader.FrameArrived -= MediaFrameReaderOnFrameArrived;
-                _dispatcherTimer.Stop();
-                _dispatcherTimer.Tick -= _dispatcherTimer_Tick;
                 SymbolStartStop = Symbol.Play;
                 SymbolStartStopColor = new SolidColorBrush(Windows.UI.Colors.Green);
 
@@ -396,7 +297,7 @@ namespace OndertitelLezerUwp.ViewModels
                 _ttsSynthesizer.Reset();
                 _trackSpokenSentences = new List<string>();
 
-                if(_mediaCapture.VideoDeviceController.ExposureControl.Supported)
+                if (_mediaCapture.VideoDeviceController.ExposureControl.Supported)
                 {
                     await _mediaCapture.VideoDeviceController.ExposureControl.SetAutoAsync(false);
                 }
@@ -405,26 +306,129 @@ namespace OndertitelLezerUwp.ViewModels
                 SymbolStartStopColor = new SolidColorBrush(Windows.UI.Colors.Red);
                 _isOcrStarted = true;
 
-                //_dispatcherTimer.Tick += _dispatcherTimer_Tick;
-                //_dispatcherTimer.Interval = new TimeSpan(0, 0, 0, 0, 600);
-                //_dispatcherTimer.Start();
+                // Realtime mode doesn't work, frames are coming in to fast. OCR can't handle it.
+                _mediaFrameReader.AcquisitionMode = MediaFrameReaderAcquisitionMode.Buffered;
 
                 _mediaFrameReader.FrameArrived += MediaFrameReaderOnFrameArrived;
                 await _mediaFrameReader.StartAsync();
-
             }
 
         }
+
+        private DateTime _lastArrival;
+        private bool _isProcessing;
 
         private async void MediaFrameReaderOnFrameArrived(MediaFrameReader sender, MediaFrameArrivedEventArgs args)
         {
             try
             {
-                await ProcessFrameOcr(_threshold);
+                MediaFrameReference frame = sender.TryAcquireLatestFrame();
+                if (frame?.VideoMediaFrame?.SoftwareBitmap == null)
+                    return;
+
+                // only process every 600ms
+                if (DateTime.Now - _lastArrival < TimeSpan.FromMilliseconds(600))
+                    return;
+
+                // stop if there is already something processing
+                if (_isProcessing)
+                    return;
+
+                _lastArrival = DateTime.Now;
+                _isProcessing = true;
+
+                var currentFrame = frame.VideoMediaFrame;
+                // Collect the resulting frame.
+                SoftwareBitmap bitmap = currentFrame.SoftwareBitmap;
+                WriteableBitmap processedBitmap;
+                SoftwareBitmap bitmapToOcr = null;
+                int oneThirdHeight = bitmap.PixelHeight / 3;
+
+                SoftwareBitmap convertedBitMap = SoftwareBitmap.Convert(bitmap, BitmapPixelFormat.Bgra8);
+
+                await OnUiThread(async () =>
+                {
+                    try
+                    {
+                        processedBitmap = new WriteableBitmap(convertedBitMap.PixelWidth, convertedBitMap.PixelHeight);
+                        convertedBitMap.CopyToBuffer(processedBitmap.PixelBuffer);
+
+                        processedBitmap = await Helpers.ImageProcessor.ApplyGaussianBlur(processedBitmap, 4);
+
+                        if (IsImageEffectsOn)
+                        {
+                            processedBitmap = await Helpers.ImageProcessor.AdjustCurvesEffect(processedBitmap);
+                            processedBitmap = await Helpers.ImageProcessor.ApplyStampThreshold(processedBitmap, _threshold);
+
+                            Log.Information($"IMG - threshold @ {_threshold}, gaussian at 4 applied before OCR.");
+                        }
+
+                        //set the preview image source - if doing image preprocessing and effects
+                        if (_isOcrStarted)
+                        {
+                            PreviewImageSource = processedBitmap;
+                            PreviewImageIsVisible = true;
+                            CaptureElementIsVisible = false;
+                        }
+
+                        if (IsOneThirdCapture)
+                        {
+                            Rect rectOneThird = new Rect(0, 0, convertedBitMap.PixelWidth, convertedBitMap.PixelHeight / 3);
+                            WriteableBitmap cropped = Helpers.ImageProcessor.CropToRectangle(processedBitmap, rectOneThird);
+                            bitmapToOcr = new SoftwareBitmap(BitmapPixelFormat.Bgra8, cropped.PixelWidth, cropped.PixelHeight);
+                            bitmapToOcr.CopyFromBuffer(cropped.PixelBuffer);
+                        }
+                        else
+                        {
+                            bitmapToOcr = new SoftwareBitmap(BitmapPixelFormat.Bgra8, processedBitmap.PixelWidth, processedBitmap.PixelHeight);
+                            bitmapToOcr.CopyFromBuffer(processedBitmap.PixelBuffer);
+                        }
+
+                        if (bitmapToOcr == null)
+                            return;
+
+                        Tuple<string, int> result = null;
+
+                        result = await _ocrDetectionService.PerformOcr(bitmapToOcr, _accuracyThreshold, _isOneThirdCapture, oneThirdHeight);
+
+                        if (result?.Item1 != null && result.Item1 != "")
+                        {
+
+                            //add to internal list keep track of spoken sentences - this is useful if an empty result is returned between two similar Ocr results (can happen if contrast is really bad for a few milliseconds)
+                            if (!SentenceHasBeenSpoken(result.Item1))
+                            {
+                                _trackSpokenSentences.Add(result.Item1);
+                                _ttsSynthesizer.AddUtteranceToSynthesize(result.Item1);
+                                await SpeechSynthiserCall();
+                                Log.Debug($"OCR result spoken and assigning to Textblox onscreen (Conf: {result.Item2}) - {result.Item1}");
+                                OcrResultText = result.Item1;
+                            }
+
+                            StatusMessage = "";
+                            StatusBackground = new SolidColorBrush(Windows.UI.Colors.Transparent);
+                        }
+
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex.GetBaseException().Message);
+                    }
+                    finally
+                    {
+                        _isProcessing = false;
+
+                    }
+                }
+                );
+
             }
-            catch (System.Exception oexc)
+            catch (Exception oexc)
             {
                 Log.Error(oexc, "Error from await _ocrDetectionService.PerformOcr(bitmapToOcr, _dispatcher);");
+            }
+            finally
+            {
+                _isProcessing = false;
             }
         }
 
@@ -432,7 +436,7 @@ namespace OndertitelLezerUwp.ViewModels
 
         #region Media Capture stuff - init and setup
         private MediaCapture _mediaCapture;
-        
+
         private MediaFrameReader _mediaFrameReader;
         public MediaCapture MediaCapture
         {
@@ -582,7 +586,7 @@ namespace OndertitelLezerUwp.ViewModels
 
         private void CalculatePreviewRotation(out VideoRotation sourceRotation, out int rotationDegrees)
         {
-           
+
             switch (displayInformation.CurrentOrientation)
             {
                 case DisplayOrientations.Portrait:
@@ -632,9 +636,11 @@ namespace OndertitelLezerUwp.ViewModels
                 var allVideoDevices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
 
                 //only wors with backpanel hard coded/ can be refactored to leverage external camera
-                DeviceInformation cameraDevice = allVideoDevices.FirstOrDefault(x => x.EnclosureLocation?.Panel == Windows.Devices.Enumeration.Panel.Back);
-               
-                
+                DeviceInformation cameraDevice =
+                    allVideoDevices.FirstOrDefault(x => x.EnclosureLocation?.Panel == Windows.Devices.Enumeration.Panel.Back)
+                    ?? allVideoDevices.FirstOrDefault();
+
+
                 if (cameraDevice == null)
                 {
                     StatusBackground = new SolidColorBrush(Windows.UI.Colors.Red);
@@ -786,7 +792,6 @@ namespace OndertitelLezerUwp.ViewModels
 
                     await colorFrameSource.SetFormatAsync(preferredFormat);
 
- 
                     _mediaFrameReader = await _mediaCapture.CreateFrameReaderAsync(colorFrameSource);
 
                     await StartPreviewAsync();
@@ -798,7 +803,6 @@ namespace OndertitelLezerUwp.ViewModels
         private async Task StartPreviewAsync()
         {
             displayRequest.RequestActive();
-
 
             MediaFlowDirection = mirroringPreview ? Windows.UI.Xaml.FlowDirection.RightToLeft : Windows.UI.Xaml.FlowDirection.LeftToRight;
             CaptureElement.Source = _mediaCapture;
@@ -826,7 +830,7 @@ namespace OndertitelLezerUwp.ViewModels
                 await SetPreviewRotationAsync();
             }
         }
-        
+
 
         private async void MediaCapture_Failed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
         {

--- a/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
+++ b/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
@@ -393,7 +393,10 @@ namespace OndertitelLezerUwp.ViewModels
                 _ttsSynthesizer.Reset();
                 _trackSpokenSentences = new List<string>();
 
-                await _mediaCapture.VideoDeviceController.ExposureControl.SetAutoAsync(false);
+                if(_mediaCapture.VideoDeviceController.ExposureControl.Supported)
+                {
+                    await _mediaCapture.VideoDeviceController.ExposureControl.SetAutoAsync(false);
+                }
 
                 SymbolStartStop = Symbol.Pause;
                 SymbolStartStopColor = new SolidColorBrush(Windows.UI.Colors.Red);

--- a/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
+++ b/src/OndertitelLezerUwp/ViewModels/MainViewModel.cs
@@ -609,7 +609,7 @@ namespace OndertitelLezerUwp.ViewModels
                 var allVideoDevices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
 
                 //only wors with backpanel hard coded/ can be refactored to leverage external camera
-                DeviceInformation cameraDevice = allVideoDevices.FirstOrDefault(x => x.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Back);
+                DeviceInformation cameraDevice = allVideoDevices.FirstOrDefault(x => x.EnclosureLocation?.Panel == Windows.Devices.Enumeration.Panel.Back);
                
                 
                 if (cameraDevice == null)


### PR DESCRIPTION
Biggest change: 
_mediaCapture.GetPreviewFrameAsync has a memory leak on Windows 1903. 
https://github.com/MicrosoftDocs/winrt-api/issues/1066
Used MediaFrameReader as work around.

Minor changes:
- Update nuget packages to latest version
- Added Serilog.Debug.Sink to log to Visual Studio output window
- Use the first camera it can find, if no back camera is available (Mostly for debugging purpose)
- Fixed null pointers and not supported exceptions.